### PR TITLE
Windows/MSVC

### DIFF
--- a/README-MSVC.txt
+++ b/README-MSVC.txt
@@ -1,0 +1,6 @@
+Building headers_workaround with Microsoft Visual Studio C++ compiler prior to MSVC 2010, including Microsoft Visual C++ Compiler for Python 2.7 
+
+MurmurHash headers depend on C99 compatible stdint.h header which is not supplied with Microsoft Visual C++ compiler prior to MSVC 2010.
+Compatible stdint.h file may be downloaded from http://msinttypes.googlecode.com/svn/trunk/stdint.h 
+It shall be placed to your VC/include folder. 
+ 

--- a/headers_workaround/murmurhash/MurmurHash2.h
+++ b/headers_workaround/murmurhash/MurmurHash2.h
@@ -5,24 +5,7 @@
 #ifndef _MURMURHASH2_H_
 #define _MURMURHASH2_H_
 
-//-----------------------------------------------------------------------------
-// Platform-specific functions and macros
-
-// Microsoft Visual Studio
-
-#if defined(_MSC_VER)
-
-typedef unsigned char uint8_t;
-typedef unsigned long uint32_t;
-typedef unsigned __int64 uint64_t;
-
-// Other compilers
-
-#else	// defined(_MSC_VER)
-
 #include <stdint.h>
-
-#endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 

--- a/headers_workaround/murmurhash/MurmurHash3.h
+++ b/headers_workaround/murmurhash/MurmurHash3.h
@@ -5,24 +5,8 @@
 #ifndef _MURMURHASH3_H_
 #define _MURMURHASH3_H_
 
-//-----------------------------------------------------------------------------
-// Platform-specific functions and macros
-
-// Microsoft Visual Studio
-
-#if defined(_MSC_VER)
-
-typedef unsigned char uint8_t;
-typedef unsigned long uint32_t;
-typedef unsigned __int64 uint64_t;
-
-// Other compilers
-
-#else	// defined(_MSC_VER)
 
 #include <stdint.h>
-
-#endif // !defined(_MSC_VER)
 
 //-----------------------------------------------------------------------------
 #ifdef __cplusplus


### PR DESCRIPTION
Typedefs for WIndows build removed from MurmurHash headers.
The reason:
- Typedefs in the original headers covered very specific environment and MSVC version
- If used with a different version or in different environment they created issues caused by multiply incompatibilities

Proposed approach:
- If Microsoft compiler is C99 compliant nothing is required -- MSVC 2010 and above
- If Microsoft compiler is not C99 compliant proper stdint.h has to be installed atop as explained in README-MSVC 
